### PR TITLE
Add TopK parameter to ChatCompletionRequest

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -50,6 +50,7 @@ type ChatCompletionRequest struct {
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
 	Temperature         float32                       `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
+	TopK                float32                       `json:"top_k,omitempty"`
 	N                   int                           `json:"n,omitempty"`
 	Stream              bool                          `json:"stream,omitempty"`
 	Stop                []string                      `json:"stop,omitempty"`


### PR DESCRIPTION
## What’s New?  
This PR adds support for the `top_k` parameter in the `ChatCompletionRequest` struct.  

## Why is this needed?  
Some models support the `top_k` parameter to control the sampling process. Adding this parameter allows users to configure it when supported.  

## Changes  
- Added `TopK` field to `ChatCompletionRequest`. 