### PR TITLE
Add support for TopK, TopA, RepetitionPenalty, and MinP parameters

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -50,12 +50,16 @@ type ChatCompletionRequest struct {
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
 	Temperature         float32                       `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
+	TopK                int                           `json:"top_k,omitempty"`
+	TopA                float32                       `json:"top_a,omitempty"`
 	N                   int                           `json:"n,omitempty"`
 	Stream              bool                          `json:"stream,omitempty"`
 	Stop                []string                      `json:"stop,omitempty"`
 	PresencePenalty     float32                       `json:"presence_penalty,omitempty"`
+	RepetitionPenalty   float32                       `json:"repetition_penalty,omitempty"`
 	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
 	Seed                *int                          `json:"seed,omitempty"`
+	MinP                float32                       `json:"min_p,omitempty"`
 	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`


### PR DESCRIPTION
## What's New?  
The following parameters have been added:  
- **`top_k` (int)** – Limits token selection to the top K most probable tokens.  
- **`top_a` (float32)** – Adjusts the probability mass dynamically, similar to TopP but with a different approach.  
- **`repetition_penalty` (float32)** – Applies a penalty to repeated tokens, helping reduce redundancy in responses.  
- **`min_p` (float32)** – Ensures that selected tokens exceed a minimum probability threshold, preventing overly low-probability completions.  

## Why is this needed?  
These additional parameters provide more control over the response generation process, allowing users to fine-tune model outputs for better performance and diversity.