### PR TITLE
Restore Multi-Modal LLM Content Support with Backward Compatibility

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -278,7 +278,7 @@ func (c ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 		ToolCallID:   c.ToolCallID,
 	}
 
-	if c.Content != "" {
+	if len(c.MultiContent) == 0 {
 		temp.Content = c.Content
 	} else {
 		temp.Content = c.MultiContent

--- a/chat_test.go
+++ b/chat_test.go
@@ -7,10 +7,10 @@ import (
 	openrouter "github.com/revrost/go-openrouter"
 )
 
-// ChatContent json.Marshal tests
+// ChatCompletionMessage json.Marshal tests
 //
 // Tests the case where MultiContent is not empty
-func TestChatContentMarshalJSON_MultiContent(t *testing.T) {
+func TestChatCompletionMessageMarshalJSON_MultiContent(t *testing.T) {
 	parts := []openrouter.ChatMessagePart{
 		{
 			Type: openrouter.ChatMessagePartTypeText,
@@ -24,9 +24,8 @@ func TestChatContentMarshalJSON_MultiContent(t *testing.T) {
 		},
 	}
 	message := openrouter.ChatCompletionMessage{
-		Role: openrouter.ChatMessageRoleUser,
-		// Content: "This is a simple content",
-		ContentValue: openrouter.NewMultiContent(parts),
+		Role:         openrouter.ChatMessageRoleUser,
+		MultiContent: parts,
 	}
 
 	expected := `{"role":"user","content":[{"type":"text","text":"What is in this image?"},{"type":"image_url","image_url":{"url":"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"}}]}`
@@ -34,36 +33,13 @@ func TestChatContentMarshalJSON_MultiContent(t *testing.T) {
 }
 
 // Tests the case where Content is used (MultiContent is empty)
-func TestChatContentMarshalJSON_Content(t *testing.T) {
-	message := openrouter.ChatCompletionMessage{
-		Role:         openrouter.ChatMessageRoleUser,
-		ContentValue: openrouter.NewContent("This is a simple content"),
-	}
-
-	expected := `{"role":"user","content":"This is a simple content"}`
-	marshalAndValidate(t, message, expected)
-}
-
-// Tests the case where Deprecated Content is used (ContentValue is empty)
-func TestChatContentMarshalJSON_DeprecatedContent(t *testing.T) {
+func TestChatCompletionMessageMarshalJSON_Content(t *testing.T) {
 	message := openrouter.ChatCompletionMessage{
 		Role:    openrouter.ChatMessageRoleUser,
 		Content: "This is a simple content",
 	}
 
 	expected := `{"role":"user","content":"This is a simple content"}`
-	marshalAndValidate(t, message, expected)
-}
-
-// Tests the case where Content and ContentValue are both used
-func TestChatContentMarshalJSON_ContentAndContentValue(t *testing.T) {
-	message := openrouter.ChatCompletionMessage{
-		Role:         openrouter.ChatMessageRoleUser,
-		Content:      "This is the deprecated content",
-		ContentValue: openrouter.NewContent("This is the new content"),
-	}
-
-	expected := `{"role":"user","content":"This is the deprecated content"}`
 	marshalAndValidate(t, message, expected)
 }
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -1,0 +1,81 @@
+package openrouter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	openrouter "github.com/revrost/go-openrouter"
+)
+
+// ChatContent json.Marshal tests
+//
+// Tests the case where MultiContent is not empty
+func TestChatContentMarshalJSON_MultiContent(t *testing.T) {
+	parts := []openrouter.ChatMessagePart{
+		{
+			Type: openrouter.ChatMessagePartTypeText,
+			Text: "What is in this image?",
+		},
+		{
+			Type: openrouter.ChatMessagePartTypeImageURL,
+			ImageURL: &openrouter.ChatMessageImageURL{
+				URL: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+			},
+		},
+	}
+	message := openrouter.ChatCompletionMessage{
+		Role: openrouter.ChatMessageRoleUser,
+		// Content: "This is a simple content",
+		ContentValue: openrouter.NewMultiContent(parts),
+	}
+
+	expected := `{"role":"user","content":[{"type":"text","text":"What is in this image?"},{"type":"image_url","image_url":{"url":"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"}}]}`
+	marshalAndValidate(t, message, expected)
+}
+
+// Tests the case where Content is used (MultiContent is empty)
+func TestChatContentMarshalJSON_Content(t *testing.T) {
+	message := openrouter.ChatCompletionMessage{
+		Role:         openrouter.ChatMessageRoleUser,
+		ContentValue: openrouter.NewContent("This is a simple content"),
+	}
+
+	expected := `{"role":"user","content":"This is a simple content"}`
+	marshalAndValidate(t, message, expected)
+}
+
+// Tests the case where Deprecated Content is used (ContentValue is empty)
+func TestChatContentMarshalJSON_DeprecatedContent(t *testing.T) {
+	message := openrouter.ChatCompletionMessage{
+		Role:    openrouter.ChatMessageRoleUser,
+		Content: "This is a simple content",
+	}
+
+	expected := `{"role":"user","content":"This is a simple content"}`
+	marshalAndValidate(t, message, expected)
+}
+
+// Tests the case where Content and ContentValue are both used
+func TestChatContentMarshalJSON_ContentAndContentValue(t *testing.T) {
+	message := openrouter.ChatCompletionMessage{
+		Role:         openrouter.ChatMessageRoleUser,
+		Content:      "This is the deprecated content",
+		ContentValue: openrouter.NewContent("This is the new content"),
+	}
+
+	expected := `{"role":"user","content":"This is the deprecated content"}`
+	marshalAndValidate(t, message, expected)
+}
+
+func marshalAndValidate(t *testing.T, message openrouter.ChatCompletionMessage, expected string) {
+	// Calls MarshalJSON
+	result, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Validates the resulting JSON
+	if string(result) != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/revrost/go-openrouter
 
-go 1.23.0
+go 1.24.1


### PR DESCRIPTION
This pull request proposes restoring support for multi-modal LLM content while ensuring backward compatibility with previous library versions.  

### **Motivation**  
While running tests with the Gemini model, I noticed that the `MultiContent` field in the `ChatCompletionMessage` struct was commented out. This PR aims to reintroduce this functionality with adjustments to maintain compatibility.  

### **Changes Introduced**  
- **New Field:** Instead of bringing back `MultiContent`, a new field named `ContentValue` has been introduced.  
  - I'm open to renaming it, but any alternative should still include "Content" for clarity.  
  - `ContentValue` is of type `ChatContent`, which includes:  
    - `Content string`  
    - `MultiContent []ChatMessagePart`  

```go
type ChatContent struct {
	content      string
	multiContent []ChatMessagePart
}

type ChatCompletionMessage struct {
	Role string `json:"role"`

	Content string `json:"content,omitzero"`

	ContentValue ChatContent `json:"content,omitzero"`

	Refusal      string      `json:"refusal,omitempty"`
	FunctionCall *FunctionCall `json:"function_call,omitempty"`
	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
	ToolCallID string `json:"tool_call_id,omitempty"`
}
```

- **Helper Functions:**  
  - `NewContent(content string) ChatContent`  
  - `NewMultiContent(parts []ChatMessagePart) ChatContent`  
  - These functions ensure correct struct usage and prevent user errors.  

- **Custom JSON Serialization:**  
  - A custom `json.Marshal` method for `ChatContent` ensures correct serialization by prioritizing `Content` if both fields are populated.  

```go
func (c ChatContent) MarshalJSON() ([]byte, error) {
	if len(c.multiContent) > 0 {
		return json.Marshal(c.multiContent)
	}

	return json.Marshal(c.content)
}
```

- **Handling `content` Field Conflict:**  
  - The existing `Content` field is now marked as **deprecated** to maintain backward compatibility.  
  - A custom `json.Marshal` implementation for `ChatCompletionMessage` was added to avoid Go's restriction on duplicate JSON tags:  
    - `"govet: structtag: struct field ContentValue repeats json tag 'content' also at Content"`  
  - This method uses a temporary struct to enforce JSON field ordering, but we could simplify it using `map[string]interface{}` if necessary.  

```go
// MarshalJSON is customized to handle the ambiguity between the deprecated field `Content`
// and the new field `ContentValue`, both of which map to the JSON tag "content".
// This ensures backward compatibility while allowing for future deprecation of `Content`.
func (c ChatCompletionMessage) MarshalJSON() ([]byte, error) {
	// Create a new struct to garanted a order
	type Temp struct {
		Role         string        `json:"role"`
		Content      any           `json:"content,omitzero"`
		Refusal      string        `json:"refusal,omitempty"`
		FunctionCall *FunctionCall `json:"function_call,omitempty"`
		ToolCalls    []ToolCall    `json:"tool_calls,omitempty"`
		ToolCallID   string        `json:"tool_call_id,omitempty"`
	}

	temp := Temp{
		Role:         c.Role,
		Refusal:      c.Refusal,
		FunctionCall: c.FunctionCall,
		ToolCalls:    c.ToolCalls,
		ToolCallID:   c.ToolCallID,
	}

	if c.Content != "" {
		temp.Content = c.Content
	} else {
		temp.Content = c.ContentValue
	}

	return json.Marshal(temp)
}
```

### **Testing**  
A comprehensive test suite was added to `chat_test.go` to validate:  
- Correct serialization of `ChatCompletionMessage` when using:  
  - The deprecated `Content` field  
  - `ContentValue.Content`  
  - `ContentValue.MultiContent`  
- A scenario where both `Content` and `ContentValue` are set:  
  - The deprecated `Content` field currently takes precedence (this behavior can be changed if needed).  


This is an initial proposal, and I’m open to feedback to further refine this approach.  

Thanks for reviewing! 🚀  