### PR TITLE
fix(gomod): lower Go version to 1.23 for greater compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,19 @@
 module github.com/revrost/go-openrouter
 
-go 1.24.1
+go 1.23
+
+toolchain go1.23.5
+
+require (
+	github.com/rs/zerolog v1.34.0
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/zerolog v1.34.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Hi,

This pull request lowers the Go version specified in go.mod from 1.24.1 to 1.23 (and the toolchain to go1.23.5).

After integrating go-openrouter into my project (Langkit) I encountered a compatibility issue while trying to use a [github action](https://github.com/dAppServer/wails-build-action) for Wails, because its target version is Go 1.23 due to CGo requirements.

Due to Go's Minimum Version Selection, your module's go 1.24.1 directive forces consuming projects to adopt Go 1.24.1 or higher. After testing, it appears the go-openrouter codebase and its current dependencies are fully compatible with Go 1.23, as `go mod tidy` completes successfully and the library builds without issue using a Go 1.23 toolchain.

1.24 is still very recent so unless you want to use its features it would be nice to lower the target version.

Thanks !