### PR TITLE
Slightly easier to use GenerateSchema func

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -64,6 +64,11 @@ func (d *Definition) Unmarshal(content string, v any) error {
 	return VerifySchemaAndUnmarshal(*d, []byte(content), v)
 }
 
+func GenerateSchema[T any]() (*Definition, error) {
+	var v T
+	return reflectSchema(reflect.TypeOf(v))
+}
+
 func GenerateSchemaForType(v any) (*Definition, error) {
 	return reflectSchema(reflect.TypeOf(v))
 }


### PR DESCRIPTION
If you don't want to have to create a new variable to pass as the type yourself