### PR TITLE
feat: add MaxResults option to ChatCompletionPlugin

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -77,8 +77,9 @@ const (
 )
 
 type ChatCompletionPlugin struct {
-	ID  PluginID   `json:"id"`
-	PDF *PDFPlugin `json:"pdf,omitempty"`
+	ID         PluginID   `json:"id"`
+	PDF        *PDFPlugin `json:"pdf,omitempty"`
+	MaxResults *int       `json:"max_results,omitempty"`
 }
 
 type PDFPlugin struct {


### PR DESCRIPTION
Adds an optional MaxResults field to allow users to control the maximum number of results returned by plugin operations.