### PR TITLE
add native_finish_reason

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -352,8 +352,9 @@ type ChatCompletionChoice struct {
 	// function_call: The model decided to call a function
 	// content_filter: Omitted content due to a flag from our content filters
 	// null: API response still in progress or incomplete
-	FinishReason FinishReason `json:"finish_reason"`
-	LogProbs     *LogProbs    `json:"logprobs,omitempty"`
+	FinishReason       FinishReason `json:"finish_reason"`
+	NativeFinishReason string       `json:"native_finish_reason"`
+	LogProbs           *LogProbs    `json:"logprobs,omitempty"`
 }
 
 type PromptAnnotation struct {
@@ -777,6 +778,7 @@ type ChatCompletionStreamChoice struct {
 	Delta                ChatCompletionStreamChoiceDelta     `json:"delta"`
 	Logprobs             *ChatCompletionStreamChoiceLogprobs `json:"logprobs,omitempty"`
 	FinishReason         FinishReason                        `json:"finish_reason"`
+	NativeFinishReason   string                              `json:"native_finish_reason"`
 	ContentFilterResults *ContentFilterResults               `json:"content_filter_results,omitempty"`
 }
 


### PR DESCRIPTION
noticed some models had finish_reason come back as "stop", but native_finish_reason vastly different