### PR TITLE
 Fix typos in basic chat example

### DIFF
--- a/examples/completion/main.go
+++ b/examples/completion/main.go
@@ -17,7 +17,7 @@ func main() {
 		Messages: []openrouter.ChatCompletionMessage{
 			{
 				Role:    openrouter.ChatMessageRoleSystem,
-				Content: openrouter.Content{Text: "You are a helfpul assistant."},
+				Content: openrouter.Content{Text: "You are a helpful assistant."},
 			},
 			{
 				Role:    openrouter.ChatMessageRoleUser,
@@ -32,6 +32,6 @@ func main() {
 		fmt.Println("error", err)
 	} else {
 		b, _ := json.MarshalIndent(res, "", "\t")
-		fmt.Printf("request :\n %s", string(b))
+		fmt.Printf("response :\n %s", string(b))
 	}
 }


### PR DESCRIPTION
Small fix; noticed a couple of typos in the basic chat example.

### Changes
- Corrected the `Printf` label from `"request"` to `"response"` (the code was printing the API response, not the request)
- Fixed a typo in the system prompt: `"helfpul"` → `"helpful"`