### PR TITLE
feat: add OpenRouter response caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ https://openrouter.ai/docs/api-reference/overview
 - [x] Tool calling
 - [x] Structured outputs
 - [x] Prompt caching
+- [x] Response caching
 - [x] Web search
 - [x] Multimodal [Images, PDFs, Audio]
 - [x] Usage fields
@@ -213,6 +214,71 @@ resp, err := client.CreateChatCompletionWithFallbackPolicy(
 
 `DefaultChatCompletionFallbackErrorCodes` returns a copy of the library default
 code list if you want to inspect or extend it.
+
+### Response caching
+
+OpenRouter response caching can be enabled per request for supported endpoint
+requests, including chat completions, streaming chat completions, and embeddings.
+This client also forwards the same headers on legacy completion requests for
+compatibility. Cache options are sent as HTTP headers and are not included in the
+JSON request body.
+
+```go
+enabled := true
+ttl := 3600
+
+resp, err := client.CreateChatCompletion(ctx, openrouter.ChatCompletionRequest{
+	Model: "openai/gpt-4o-mini",
+	Messages: []openrouter.ChatCompletionMessage{
+		openrouter.UserMessage("Summarize this transcript."),
+	},
+	ResponseCache: &openrouter.ResponseCacheConfig{
+		Enabled:    &enabled,
+		TTLSeconds: &ttl,
+	},
+})
+if err != nil {
+	fmt.Printf("ChatCompletion error: %v\n", err)
+	return
+}
+
+if resp.ResponseCache != nil && resp.ResponseCache.Status == openrouter.ResponseCacheStatusHit {
+	fmt.Printf("cache hit, age=%d seconds\n", *resp.ResponseCache.AgeSeconds)
+}
+```
+
+Use `Clear: true` to send `X-OpenRouter-Cache-Clear: true` for a request:
+
+```go
+resp, err := client.CreateEmbeddings(ctx, openrouter.EmbeddingsRequest{
+	Model: "openai/text-embedding-3-small",
+	Input: "hello",
+	ResponseCache: &openrouter.ResponseCacheConfig{
+		Clear: true,
+	},
+})
+```
+
+Streaming responses expose cache metadata from the initial response headers:
+
+```go
+stream, err := client.CreateChatCompletionStream(ctx, openrouter.ChatCompletionRequest{
+	Model: "openai/gpt-4o-mini",
+	Messages: []openrouter.ChatCompletionMessage{
+		openrouter.UserMessage("Write a short update."),
+	},
+	ResponseCache: &openrouter.ResponseCacheConfig{
+		Enabled: &enabled,
+	},
+})
+if err != nil {
+	fmt.Printf("ChatCompletionStream error: %v\n", err)
+	return
+}
+defer stream.Close()
+
+metadata := stream.ResponseCacheMetadata()
+```
 
 ### Other examples:
 

--- a/chat.go
+++ b/chat.go
@@ -142,6 +142,9 @@ type ChatCompletionRequest struct {
 	Provider *ChatProvider           `json:"provider,omitempty"`
 	Messages []ChatCompletionMessage `json:"messages"`
 
+	// ResponseCache controls OpenRouter response caching headers for this request.
+	ResponseCache *ResponseCacheConfig `json:"-"`
+
 	Reasoning *ChatCompletionReasoning `json:"reasoning,omitempty"`
 
 	Plugins    []ChatCompletionPlugin   `json:"plugins,omitempty"`
@@ -297,7 +300,8 @@ type ChatCompletionResponse struct {
 	Usage             *Usage                 `json:"usage,omitempty"`
 	SystemFingerprint string                 `json:"system_fingerprint"`
 
-	// http.Header
+	// ResponseCache contains OpenRouter response cache metadata from response headers.
+	ResponseCache *ResponseCacheMetadata `json:"-"`
 }
 
 type TopLogProbs struct {
@@ -807,6 +811,14 @@ type ChatCompletionStream struct {
 	stream   <-chan ChatCompletionStreamResponse
 	done     chan struct{}
 	response *http.Response
+}
+
+// ResponseCacheMetadata returns OpenRouter response cache metadata from the initial stream response headers.
+func (s *ChatCompletionStream) ResponseCacheMetadata() *ResponseCacheMetadata {
+	if s == nil || s.response == nil {
+		return nil
+	}
+	return parseResponseCacheMetadata(s.response.Header)
 }
 
 // CreateChatCompletionStreamWithFallback tries request.Model first, then

--- a/client.go
+++ b/client.go
@@ -54,7 +54,11 @@ func (c *Client) sendRequest(req *http.Request, v any) error {
 		return c.handleErrorResp(res)
 	}
 
-	return decodeResponse(res.Body, v)
+	if err := decodeResponse(res.Body, v); err != nil {
+		return err
+	}
+	setResponseCacheMetadata(v, res.Header)
+	return nil
 }
 
 func (c *Client) setCommonHeaders(req *http.Request) {
@@ -148,6 +152,7 @@ func (c *Client) newRequest(ctx context.Context, method, url string, setters ...
 	if err != nil {
 		return nil, err
 	}
+	setResponseCacheHeadersFromBody(req.Header, args.body)
 	c.setCommonHeaders(req)
 	return req, nil
 }
@@ -167,6 +172,7 @@ func (c *Client) newStreamRequest(
 		return nil, err
 	}
 
+	setResponseCacheHeadersFromBody(req.Header, body)
 	c.setCommonHeaders(req)
 	return req, nil
 }

--- a/completion.go
+++ b/completion.go
@@ -23,6 +23,8 @@ type CompletionRequest struct {
 	Model string `json:"model,omitempty"`
 	// The prompt to complete
 	Prompt string `json:"prompt"`
+	// ResponseCache controls OpenRouter response caching headers for this request.
+	ResponseCache *ResponseCacheConfig `json:"-"`
 	// Optional model fallbacks: https://openrouter.ai/docs/features/model-routing#the-models-parameter
 	Models    []string                 `json:"models,omitempty"`
 	Provider  *ChatProvider            `json:"provider,omitempty"`
@@ -81,6 +83,8 @@ type CompletionResponse struct {
 	Citations         []string           `json:"citations"`
 	Usage             *Usage             `json:"usage,omitempty"`
 	SystemFingerprint string             `json:"system_fingerprint"`
+	// ResponseCache contains OpenRouter response cache metadata from response headers.
+	ResponseCache *ResponseCacheMetadata `json:"-"`
 }
 
 // CreateCompletion — API call to Create a completion for the prompt.
@@ -116,6 +120,14 @@ type CompletionStream struct {
 	stream   <-chan CompletionResponse
 	done     chan struct{}
 	response *http.Response
+}
+
+// ResponseCacheMetadata returns OpenRouter response cache metadata from the initial stream response headers.
+func (s *CompletionStream) ResponseCacheMetadata() *ResponseCacheMetadata {
+	if s == nil || s.response == nil {
+		return nil
+	}
+	return parseResponseCacheMetadata(s.response.Header)
 }
 
 // CreateCompletionStream — API call to Create a completion for the prompt with streaming.

--- a/embeddings.go
+++ b/embeddings.go
@@ -35,6 +35,9 @@ type EmbeddingsRequest struct {
 	// Input is the content to embed. See the API docs for supported formats.
 	Input any `json:"input"`
 
+	// ResponseCache controls OpenRouter response caching headers for this request.
+	ResponseCache *ResponseCacheConfig `json:"-"`
+
 	// EncodingFormat controls how the embedding is returned: "float" or "base64".
 	EncodingFormat EmbeddingsEncodingFormat `json:"encoding_format,omitempty"`
 	// Dimensions optionally truncates the embedding to the given number of dimensions.
@@ -96,6 +99,8 @@ type EmbeddingsResponse struct {
 	Data   []EmbeddingData  `json:"data"`
 	Model  string           `json:"model"`
 	Usage  *EmbeddingsUsage `json:"usage,omitempty"`
+	// ResponseCache contains OpenRouter response cache metadata from response headers.
+	ResponseCache *ResponseCacheMetadata `json:"-"`
 }
 
 // CreateEmbeddings submits an embedding request to the embeddings router.

--- a/response_cache.go
+++ b/response_cache.go
@@ -1,0 +1,119 @@
+package openrouter
+
+import (
+	"net/http"
+	"strconv"
+)
+
+const (
+	headerResponseCache       = "X-OpenRouter-Cache"
+	headerResponseCacheTTL    = "X-OpenRouter-Cache-TTL"
+	headerResponseCacheClear  = "X-OpenRouter-Cache-Clear"
+	headerResponseCacheStatus = "X-OpenRouter-Cache-Status"
+	headerResponseCacheAge    = "X-OpenRouter-Cache-Age"
+)
+
+const (
+	ResponseCacheStatusHit  ResponseCacheStatus = "HIT"
+	ResponseCacheStatusMiss ResponseCacheStatus = "MISS"
+)
+
+// ResponseCacheStatus is the cache result returned by OpenRouter.
+type ResponseCacheStatus string
+
+// ResponseCacheConfig controls OpenRouter response caching headers for a request.
+type ResponseCacheConfig struct {
+	// Enabled sets X-OpenRouter-Cache to true or false when provided.
+	Enabled *bool
+	// TTLSeconds sets X-OpenRouter-Cache-TTL when provided.
+	// OpenRouter accepts values from 1 to 86400 seconds.
+	TTLSeconds *int
+	// Clear sets X-OpenRouter-Cache-Clear to true.
+	Clear bool
+}
+
+// ResponseCacheMetadata contains OpenRouter response cache headers returned by the API.
+type ResponseCacheMetadata struct {
+	Status     ResponseCacheStatus
+	AgeSeconds *int
+	TTLSeconds *int
+}
+
+func setResponseCacheHeaders(header http.Header, cache *ResponseCacheConfig) {
+	if cache == nil {
+		return
+	}
+	if cache.Enabled != nil {
+		header.Set(headerResponseCache, strconv.FormatBool(*cache.Enabled))
+	}
+	if cache.TTLSeconds != nil {
+		header.Set(headerResponseCacheTTL, strconv.Itoa(*cache.TTLSeconds))
+	}
+	if cache.Clear {
+		header.Set(headerResponseCacheClear, "true")
+	}
+}
+
+func setResponseCacheHeadersFromBody(header http.Header, body any) {
+	switch request := body.(type) {
+	case ChatCompletionRequest:
+		setResponseCacheHeaders(header, request.ResponseCache)
+	case *ChatCompletionRequest:
+		if request != nil {
+			setResponseCacheHeaders(header, request.ResponseCache)
+		}
+	case CompletionRequest:
+		setResponseCacheHeaders(header, request.ResponseCache)
+	case *CompletionRequest:
+		if request != nil {
+			setResponseCacheHeaders(header, request.ResponseCache)
+		}
+	case EmbeddingsRequest:
+		setResponseCacheHeaders(header, request.ResponseCache)
+	case *EmbeddingsRequest:
+		if request != nil {
+			setResponseCacheHeaders(header, request.ResponseCache)
+		}
+	}
+}
+
+func parseResponseCacheMetadata(header http.Header) *ResponseCacheMetadata {
+	status := header.Get(headerResponseCacheStatus)
+	age := parseHeaderInt(header, headerResponseCacheAge)
+	ttl := parseHeaderInt(header, headerResponseCacheTTL)
+	if status == "" && age == nil && ttl == nil {
+		return nil
+	}
+	return &ResponseCacheMetadata{
+		Status:     ResponseCacheStatus(status),
+		AgeSeconds: age,
+		TTLSeconds: ttl,
+	}
+}
+
+func parseHeaderInt(header http.Header, key string) *int {
+	value := header.Get(key)
+	if value == "" {
+		return nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func setResponseCacheMetadata(v any, header http.Header) {
+	metadata := parseResponseCacheMetadata(header)
+	if metadata == nil {
+		return
+	}
+	switch response := v.(type) {
+	case *ChatCompletionResponse:
+		response.ResponseCache = metadata
+	case *CompletionResponse:
+		response.ResponseCache = metadata
+	case *EmbeddingsResponse:
+		response.ResponseCache = metadata
+	}
+}

--- a/response_cache.go
+++ b/response_cache.go
@@ -45,6 +45,8 @@ func setResponseCacheHeaders(header http.Header, cache *ResponseCacheConfig) {
 	}
 	if cache.Enabled != nil {
 		header.Set(headerResponseCache, strconv.FormatBool(*cache.Enabled))
+	} else if cache.Clear {
+		header.Set(headerResponseCache, "true")
 	}
 	if cache.TTLSeconds != nil {
 		header.Set(headerResponseCacheTTL, strconv.Itoa(*cache.TTLSeconds))

--- a/response_cache_test.go
+++ b/response_cache_test.go
@@ -1,0 +1,214 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateChatCompletionResponseCacheHeadersAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	ttl := 3600
+	httpClient := &fakeHTTPClient{
+		response: responseCacheJSONResponse(`{
+			"id":"chatcmpl_1",
+			"object":"chat.completion",
+			"model":"openai/gpt-4o-mini",
+			"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]
+		}`),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	resp, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
+		Model: "openai/gpt-4o-mini",
+		Messages: []ChatCompletionMessage{
+			UserMessage("hello"),
+		},
+		ResponseCache: &ResponseCacheConfig{
+			Enabled:    &enabled,
+			TTLSeconds: &ttl,
+			Clear:      true,
+		},
+	})
+
+	require.NoError(t, err)
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "true", "3600", "true")
+	requireRequestBodyOmitsResponseCache(t, httpClient.lastRequest)
+	require.NotNil(t, resp.ResponseCache)
+	require.Equal(t, ResponseCacheStatusHit, resp.ResponseCache.Status)
+	require.NotNil(t, resp.ResponseCache.AgeSeconds)
+	require.Equal(t, 42, *resp.ResponseCache.AgeSeconds)
+	require.NotNil(t, resp.ResponseCache.TTLSeconds)
+	require.Equal(t, 3600, *resp.ResponseCache.TTLSeconds)
+}
+
+func TestCreateCompletionResponseCacheHeadersAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	enabled := false
+	httpClient := &fakeHTTPClient{
+		response: responseCacheJSONResponse(`{
+			"id":"cmpl_1",
+			"object":"text_completion",
+			"model":"openai/gpt-4o-mini",
+			"choices":[{"text":"ok","finish_reason":"stop"}]
+		}`),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	resp, err := client.CreateCompletion(context.Background(), CompletionRequest{
+		Model:  "openai/gpt-4o-mini",
+		Prompt: "hello",
+		ResponseCache: &ResponseCacheConfig{
+			Enabled: &enabled,
+		},
+	})
+
+	require.NoError(t, err)
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "false", "", "")
+	requireRequestBodyOmitsResponseCache(t, httpClient.lastRequest)
+	require.NotNil(t, resp.ResponseCache)
+	require.Equal(t, ResponseCacheStatusHit, resp.ResponseCache.Status)
+}
+
+func TestCreateEmbeddingsResponseCacheHeadersAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	ttl := 120
+	httpClient := &fakeHTTPClient{
+		response: responseCacheJSONResponse(`{
+			"id":"embd_1",
+			"object":"list",
+			"data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],
+			"model":"test-embeddings-model"
+		}`),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	resp, err := client.CreateEmbeddings(context.Background(), EmbeddingsRequest{
+		Model: "test-embeddings-model",
+		Input: "hello",
+		ResponseCache: &ResponseCacheConfig{
+			TTLSeconds: &ttl,
+		},
+	})
+
+	require.NoError(t, err)
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "", "120", "")
+	requireRequestBodyOmitsResponseCache(t, httpClient.lastRequest)
+	require.NotNil(t, resp.ResponseCache)
+	require.Equal(t, ResponseCacheStatusHit, resp.ResponseCache.Status)
+}
+
+func TestCreateChatCompletionStreamResponseCacheHeadersAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	httpClient := &fakeHTTPClient{
+		response: responseCacheStreamResponse(strings.Join([]string{
+			`data: {"id":"chatcmpl_1","model":"openai/gpt-4o-mini","choices":[{"delta":{"content":"ok"}}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n")),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	stream, err := client.CreateChatCompletionStream(context.Background(), ChatCompletionRequest{
+		Model:         "openai/gpt-4o-mini",
+		Messages:      []ChatCompletionMessage{UserMessage("hello")},
+		ResponseCache: &ResponseCacheConfig{Enabled: &enabled},
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "true", "", "")
+	metadata := stream.ResponseCacheMetadata()
+	require.NotNil(t, metadata)
+	require.Equal(t, ResponseCacheStatusHit, metadata.Status)
+}
+
+func TestCreateCompletionStreamResponseCacheHeadersAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	ttl := 60
+	httpClient := &fakeHTTPClient{
+		response: responseCacheStreamResponse(strings.Join([]string{
+			`data: {"id":"cmpl_1","model":"openai/gpt-4o-mini","choices":[{"text":"ok"}]}`,
+			`data: [DONE]`,
+			``,
+		}, "\n")),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	stream, err := client.CreateCompletionStream(context.Background(), CompletionRequest{
+		Model:         "openai/gpt-4o-mini",
+		Prompt:        "hello",
+		ResponseCache: &ResponseCacheConfig{TTLSeconds: &ttl},
+	})
+	require.NoError(t, err)
+	defer stream.Close()
+
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "", "60", "")
+	metadata := stream.ResponseCacheMetadata()
+	require.NotNil(t, metadata)
+	require.Equal(t, ResponseCacheStatusHit, metadata.Status)
+}
+
+func newResponseCacheTestClient(httpClient HTTPDoer) *Client {
+	cfg := DefaultConfig("test-token")
+	cfg.BaseURL = "https://example.com/api/v1"
+	cfg.HTTPClient = httpClient
+	return NewClientWithConfig(*cfg)
+}
+
+func requireResponseCacheRequestHeaders(
+	t *testing.T,
+	req *http.Request,
+	enabled string,
+	ttl string,
+	clear string,
+) {
+	t.Helper()
+
+	require.NotNil(t, req)
+	require.Equal(t, enabled, req.Header.Get(headerResponseCache))
+	require.Equal(t, ttl, req.Header.Get(headerResponseCacheTTL))
+	require.Equal(t, clear, req.Header.Get(headerResponseCacheClear))
+}
+
+func requireRequestBodyOmitsResponseCache(t *testing.T, req *http.Request) {
+	t.Helper()
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.NotContains(t, payload, "ResponseCache")
+	require.NotContains(t, payload, "response_cache")
+}
+
+func responseCacheJSONResponse(body string) *http.Response {
+	resp := jsonResponse(http.StatusOK, body)
+	addResponseCacheHeaders(resp.Header)
+	return resp
+}
+
+func responseCacheStreamResponse(body string) *http.Response {
+	resp := jsonResponse(http.StatusOK, body)
+	addResponseCacheHeaders(resp.Header)
+	return resp
+}
+
+func addResponseCacheHeaders(header http.Header) {
+	header.Set(headerResponseCacheStatus, string(ResponseCacheStatusHit))
+	header.Set(headerResponseCacheAge, "42")
+	header.Set(headerResponseCacheTTL, "3600")
+}

--- a/response_cache_test.go
+++ b/response_cache_test.go
@@ -107,6 +107,31 @@ func TestCreateEmbeddingsResponseCacheHeadersAndMetadata(t *testing.T) {
 	require.Equal(t, ResponseCacheStatusHit, resp.ResponseCache.Status)
 }
 
+func TestResponseCacheClearEnablesCacheWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &fakeHTTPClient{
+		response: responseCacheJSONResponse(`{
+			"id":"embd_1",
+			"object":"list",
+			"data":[{"object":"embedding","embedding":[0.1,0.2],"index":0}],
+			"model":"test-embeddings-model"
+		}`),
+	}
+	client := newResponseCacheTestClient(httpClient)
+
+	_, err := client.CreateEmbeddings(context.Background(), EmbeddingsRequest{
+		Model: "test-embeddings-model",
+		Input: "hello",
+		ResponseCache: &ResponseCacheConfig{
+			Clear: true,
+		},
+	})
+
+	require.NoError(t, err)
+	requireResponseCacheRequestHeaders(t, httpClient.lastRequest, "true", "", "true")
+}
+
 func TestCreateChatCompletionStreamResponseCacheHeadersAndMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add per-request `ResponseCacheConfig` support for OpenRouter response caching headers
- expose response cache metadata on chat, completion, and embeddings responses
- expose stream cache metadata via `ResponseCacheMetadata()` helpers
- document response caching usage in the README

## Verification
- `OPENROUTER_API_KEY= GOTOOLCHAIN=local GOCACHE=/private/tmp/go-openrouter-gocache /Users/revrost/.local/share/mise/installs/go/1.25.1/bin/go test ./...`
